### PR TITLE
fix(navbar): keep active pill synced during shell morph

### DIFF
--- a/components/layout/GlassNavbar.tsx
+++ b/components/layout/GlassNavbar.tsx
@@ -50,6 +50,8 @@ export default function GlassNavbar() {
   const tabRefs = useRef<Map<string, HTMLLIElement>>(new Map());
   const [indicator, setIndicator] = useState({ left: 0, width: 0, top: 0, height: 0 });
   const [indicatorReady, setIndicatorReady] = useState(false);
+  const [shellMorphing, setShellMorphing] = useState(false);
+  const scrolledPrevMorphRef = useRef<boolean | undefined>(undefined);
 
   const isHome = pathname === "/";
   const activeHref = navItems.find((item) =>
@@ -73,11 +75,19 @@ export default function GlassNavbar() {
 
     const headerRect = headerRef.current.getBoundingClientRect();
     const targetRect = targetEl.getBoundingClientRect();
-    setIndicator({
+    const next = {
       left: targetRect.left - headerRect.left,
       width: targetRect.width,
       top: targetRect.top - headerRect.top,
       height: targetRect.height
+    };
+    setIndicator((prev) => {
+      const near =
+        Math.abs(prev.left - next.left) < 0.35 &&
+        Math.abs(prev.top - next.top) < 0.35 &&
+        Math.abs(prev.width - next.width) < 0.35 &&
+        Math.abs(prev.height - next.height) < 0.35;
+      return near ? prev : next;
     });
     setIndicatorReady(true);
   }, [isHome, activeHref]);
@@ -85,6 +95,40 @@ export default function GlassNavbar() {
   useLayoutEffect(() => {
     measureIndicator();
   }, [measureIndicator]);
+
+  useLayoutEffect(() => {
+    if (scrolledPrevMorphRef.current === undefined) {
+      scrolledPrevMorphRef.current = scrolled;
+      return;
+    }
+    if (scrolledPrevMorphRef.current === scrolled) return;
+    scrolledPrevMorphRef.current = scrolled;
+
+    setShellMorphing(true);
+    let raf = 0;
+    let alive = true;
+    const tick = () => {
+      if (!alive) return;
+      measureIndicator();
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+
+    const finish = () => {
+      if (!alive) return;
+      alive = false;
+      cancelAnimationFrame(raf);
+      setShellMorphing(false);
+      measureIndicator();
+    };
+
+    const t = window.setTimeout(finish, 560);
+    return () => {
+      alive = false;
+      cancelAnimationFrame(raf);
+      clearTimeout(t);
+    };
+  }, [scrolled, measureIndicator]);
 
   useEffect(() => {
     window.addEventListener("resize", measureIndicator);
@@ -133,20 +177,20 @@ export default function GlassNavbar() {
         )}
       >
         <header ref={headerRef} className="relative flex h-14 items-center justify-between px-5 sm:px-6">
-          {indicatorReady && (
-            <div
-              aria-hidden
-              className="absolute z-[1] rounded-full bg-white/90 dark:bg-white/[0.1] shadow-[0_1px_3px_rgba(0,0,0,0.08),0_0_0_0.5px_rgba(0,0,0,0.04)] dark:shadow-[0_1px_3px_rgba(0,0,0,0.2)]"
-              style={{
-                left: indicator.left,
-                top: indicator.top,
-                width: indicator.width,
-                height: indicator.height,
-                transition:
-                  "left 0.45s cubic-bezier(0.4, 0, 0.2, 1), width 0.35s cubic-bezier(0.4, 0, 0.2, 1), top 0.35s cubic-bezier(0.4, 0, 0.2, 1), height 0.3s cubic-bezier(0.4, 0, 0.2, 1)"
-              }}
-            />
-          )}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute z-[1] rounded-full bg-white/90 dark:bg-white/[0.1] shadow-[0_1px_3px_rgba(0,0,0,0.08),0_0_0_0.5px_rgba(0,0,0,0.04)] dark:shadow-[0_1px_3px_rgba(0,0,0,0.2)]"
+            style={{
+              left: indicator.left,
+              top: indicator.top,
+              width: indicator.width,
+              height: indicator.height,
+              opacity: indicatorReady && indicator.width > 0 ? 1 : 0,
+              transition: shellMorphing
+                ? "opacity 0.15s ease-out"
+                : "left 0.32s cubic-bezier(0.25, 0.8, 0.25, 1), top 0.32s cubic-bezier(0.25, 0.8, 0.25, 1), width 0.32s cubic-bezier(0.25, 0.8, 0.25, 1), height 0.32s cubic-bezier(0.25, 0.8, 0.25, 1), opacity 0.15s ease-out"
+            }}
+          />
 
           <Link
             ref={logoRef}


### PR DESCRIPTION
## Summary

- Fix the GlassNavbar active highlight jumping or tweening from the wrong origin when the nav shell animates between pill and full-width (scroll state).
- During that morph, sample the target tab (or logo) every animation frame and temporarily disable geometry transitions on the pill so it stays locked to the target.
- Keep the indicator in the DOM and use opacity for visibility; use consistent easing/duration for geometry when changing routes; dedupe nearly identical measurements to reduce rerenders.

## Test plan

- [ ] On desktop (sm+), scroll past the threshold: active pill should stay under Blog/Essay/Terms without sliding in from an arbitrary position.
- [ ] Scroll back to top: morph to pill layout; highlight should track correctly.
- [ ] Switch between Blog / Essay / Terms: highlight should animate smoothly from the previous item.
- [ ] Home vs section: logo vs tab highlight still measures correctly.