### PR TITLE
style(ui): smooth navbar transition and use ScrollShadow for post description

### DIFF
--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { Card } from "@heroui/react/card";
+import { ScrollShadow } from "@heroui/react/scroll-shadow";
 import { cn } from "@/lib/cn";
 import type { Author, PostMeta } from "@/lib/content";
 import dayjs from "@/lib/dayjs";
@@ -45,9 +46,11 @@ export default function PostCard({ post, authors, basePath }: PostCardProps) {
           </h3>
 
           {post.description && (
-            <p className="text-[13.5px] leading-relaxed text-zinc-500 dark:text-zinc-400 line-clamp-2">
-              {post.description}
-            </p>
+            <ScrollShadow className="max-h-[2.75rem]" hideScrollBar>
+              <p className="text-[13.5px] leading-relaxed text-zinc-500 dark:text-zinc-400">
+                {post.description}
+              </p>
+            </ScrollShadow>
           )}
 
           <div className="flex items-center justify-between pt-1">

--- a/components/layout/GlassNavbar.tsx
+++ b/components/layout/GlassNavbar.tsx
@@ -122,7 +122,7 @@ export default function GlassNavbar() {
       measureIndicator();
     };
 
-    const t = window.setTimeout(finish, 560);
+    const t = window.setTimeout(finish, 720);
     return () => {
       alive = false;
       cancelAnimationFrame(raf);
@@ -163,17 +163,17 @@ export default function GlassNavbar() {
   return (
     <div
       className={cn(
-        "sticky z-40 w-full transition-all duration-500 ease-[cubic-bezier(0.25,1,0.5,1)]",
+        "sticky z-40 w-full transition-all duration-[640ms] ease-[cubic-bezier(0.4,0,0.2,1)] motion-reduce:transition-none",
         scrolled ? "top-0 pt-0" : "top-0 pt-3"
       )}
     >
       <nav
         ref={navRef}
         className={cn(
-          "mx-auto bg-white/72 dark:bg-zinc-900/72 backdrop-saturate-[1.8] backdrop-blur-xl transition-all duration-500 ease-[cubic-bezier(0.25,1,0.5,1)]",
+          "mx-auto bg-white/72 dark:bg-zinc-900/72 backdrop-saturate-[1.8] backdrop-blur-xl transition-all duration-[640ms] ease-[cubic-bezier(0.4,0,0.2,1)] motion-reduce:transition-none",
           scrolled
-            ? "w-full max-w-none rounded-none shadow-[0_0.5px_0_rgba(0,0,0,0.06)] dark:shadow-[0_0.5px_0_rgba(255,255,255,0.06)]"
-            : "max-w-3xl rounded-full shadow-[0_2px_12px_rgba(0,0,0,0.08),0_0_0_0.5px_rgba(0,0,0,0.04)] dark:shadow-[0_2px_12px_rgba(0,0,0,0.3),0_0_0_0.5px_rgba(255,255,255,0.06)]"
+            ? "w-full max-w-full rounded-none shadow-[0_0.5px_0_rgba(0,0,0,0.06)] dark:shadow-[0_0.5px_0_rgba(255,255,255,0.06)]"
+            : "w-full max-w-3xl rounded-full shadow-[0_2px_12px_rgba(0,0,0,0.08),0_0_0_0.5px_rgba(0,0,0,0.04)] dark:shadow-[0_2px_12px_rgba(0,0,0,0.3),0_0_0_0.5px_rgba(255,255,255,0.06)]"
         )}
       >
         <header ref={headerRef} className="relative flex h-14 items-center justify-between px-5 sm:px-6">
@@ -188,7 +188,7 @@ export default function GlassNavbar() {
               opacity: indicatorReady && indicator.width > 0 ? 1 : 0,
               transition: shellMorphing
                 ? "opacity 0.15s ease-out"
-                : "left 0.32s cubic-bezier(0.25, 0.8, 0.25, 1), top 0.32s cubic-bezier(0.25, 0.8, 0.25, 1), width 0.32s cubic-bezier(0.25, 0.8, 0.25, 1), height 0.32s cubic-bezier(0.25, 0.8, 0.25, 1), opacity 0.15s ease-out"
+                : "left 0.52s cubic-bezier(0.4, 0, 0.2, 1), top 0.52s cubic-bezier(0.4, 0, 0.2, 1), width 0.52s cubic-bezier(0.4, 0, 0.2, 1), height 0.52s cubic-bezier(0.4, 0, 0.2, 1), opacity 0.15s ease-out"
             }}
           />
 

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -43,7 +43,7 @@ const extractDate = (filePath: string): string => {
   return "1970-01-01";
 };
 
-const extractExcerpt = (content: string, maxLen = 160): string | undefined => {
+const extractExcerpt = (content: string): string | undefined => {
   const truncateMatch = content.match(/<!--\s*truncate\s*-->/);
   const raw = truncateMatch
     ? content.slice(0, truncateMatch.index)
@@ -53,8 +53,7 @@ const extractExcerpt = (content: string, maxLen = 160): string | undefined => {
 
   const plain = stripMarkdown(raw) as string;
 
-  if (!plain) return undefined;
-  return plain.length > maxLen ? plain.slice(0, maxLen) + "…" : plain;
+  return plain || undefined;
 };
 
 const resolvePartialImports = (content: string, filePath: string): string => {
@@ -277,7 +276,7 @@ export const getPostBySlug = (
         ? data.authors
         : [data.authors || "heliannuuthus"],
       tags: Array.isArray(data.tags) ? data.tags : [],
-      description: data.description || extractExcerpt(content, 2000),
+      description: data.description || extractExcerpt(content),
       unlisted: !!data.unlisted,
       draft: !!data.draft
     },

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -65,6 +65,7 @@ body {
 /* ─── Apple-style surface system ─── */
 
 .surface {
+  --surface-opaque: #fdfdfd;
   background: rgba(255, 255, 255, 0.8);
   backdrop-filter: saturate(180%) blur(20px);
   -webkit-backdrop-filter: saturate(180%) blur(20px);
@@ -75,6 +76,7 @@ body {
 }
 
 .dark .surface {
+  --surface-opaque: #242424;
   background: rgba(38, 38, 38, 0.72);
   box-shadow:
     0 0 0 0.5px rgba(255, 255, 255, 0.06),
@@ -83,6 +85,7 @@ body {
 }
 
 .surface-raised {
+  --surface-opaque: #fefefe;
   background: rgba(255, 255, 255, 0.92);
   backdrop-filter: saturate(180%) blur(20px);
   -webkit-backdrop-filter: saturate(180%) blur(20px);
@@ -93,6 +96,7 @@ body {
 }
 
 .dark .surface-raised {
+  --surface-opaque: #2a2a2a;
   background: rgba(44, 44, 44, 0.85);
   box-shadow:
     0 0 0 0.5px rgba(255, 255, 255, 0.08),


### PR DESCRIPTION
## Summary
- **Navbar 过渡平滑化**：时长 500ms → 640ms，曲线改为 Material 标准衰减 `cubic-bezier(0.4,0,0.2,1)`，`max-w-none` → `max-w-full` 使宽度可插值，指示器动画同步对齐，新增 `motion-reduce` 支持
- **PostCard 摘要改用 ScrollShadow**：去掉 `line-clamp-2` 及自定义展开/收起逻辑，改用 HeroUI `ScrollShadow` 组件，默认两行、允许滚动查看全文
- **移除 JS 层摘要截断**：`extractExcerpt` 不再硬截 160 字符 + `…`，由 UI 层控制溢出展示
- **Surface 系统新增 `--surface-opaque` CSS 变量**：预混合不透明近似色，供子元素渐变匹配使用

## Test plan
- [ ] 滚动页面验证 navbar 胶囊 ↔ 顶栏过渡是否更平滑
- [ ] 检查 blog/essay 列表卡片摘要溢出时底部出现 ScrollShadow 渐变
- [ ] 验证摘要可滚动查看完整内容，滚动条隐藏
- [ ] 暗色模式下 ScrollShadow 渐变颜色是否正常
- [ ] 启用 `prefers-reduced-motion` 验证 navbar 动画被禁用